### PR TITLE
Change absence of directory statement from a fatal error to a warning

### DIFF
--- a/mkrdns
+++ b/mkrdns
@@ -220,7 +220,10 @@ qq{(warn) Include found before named directory was specified!  Using ".".\n};
   print "(debug) Read in $bootfile.\n" if ($debug);
 
   # no directory statement anywhere?
-  die "(fatal) No named directory specified!\n" unless ($nameddir);
+  unless ($nameddir) {
+    $nameddir = ".";
+    warn qq{(warn) No named directory specified!  Using ".".\n};
+  }
 
   if ( $type eq "boot" ) {              # parse named.boot
                                         # deal with directives


### PR DESCRIPTION
In some cases, it's useful to process a sub-file which may not have a directory statement. This changes the fatal error into a warning to allow processing without creating a dummy stub file to fool the script.