### PR TITLE
Update hardcoded perl path in the shebang

### DIFF
--- a/mkrdns
+++ b/mkrdns
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # mkrdns - Make Reverse DNS - Version 3.3
 #

--- a/mkrdns.dist
+++ b/mkrdns.dist
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # mkrdns - Make Reverse DNS - Version 3.3
 #


### PR DESCRIPTION
Allows the use of the script on FreeBSD and other systems that do not install perl in the `/usr/bin` folder.